### PR TITLE
Update email notifications - draft only

### DIFF
--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -37,12 +37,12 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
 
 
 def get_score_dict(score):
-    strings = [""]
-    for key in score.keys():
-        string = f"{key} : {score[key][0]}" + "\n"
-        strings.append(string)
+        strs = [""]
+        for key in score.keys():
+            str = f"{key} : {score[key][0]}"+"\n"
+            strs.append(str)
 
-    return strings
+        return strs
 
 
 def email_template(
@@ -73,9 +73,8 @@ def email_template(
         (
             "VALIDATED",
             "yes",
-        ): f"Submission {submission_id} has been evaluated with the following scores:\n"
-        + "\n".join(get_score_dict(score))
-        + f"\nView all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
+        ):
+        f"Submission {submission_id} has been evaluated with the following scores:\n" + "\n".join(get_score_dict(score)) + f"\nView all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         (
             "VALIDATED",
             "no",
@@ -126,6 +125,7 @@ def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTupl
         "submissionAnnotations"
     ]
     submission_status = submission_annotations.get("validation_status")[0]
+    submission_scores = submission_annotations.get("auc")[0]
     error_reason = submission_annotations.get("validation_errors")[0]
 
     # TODO: A more elegant way to only get the score annotations?
@@ -136,7 +136,7 @@ def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTupl
         "validation_status",
     ]
     submission_scores = {
-        key: submission_annotations.get(key)
+        key:submission_annotations.get(key)
         for key in submission_annotations.keys()
         if key not in non_score_annotations
     }


### PR DESCRIPTION
The updated send_email.py script for the Dynamic AI Challenge is uploaded [here](https://www.synapse.org/#!Synapse:syn53695537), which includes the following changes:

- The email subject has been updated to include the evaluation name. This change helps distinguish these notifications from emails related to other challenges or evaluations submitted simultaneously.
- The email body has been modified to direct participants to the “Submission” tab of the challenge, allowing them to view their own submissions.
- Remove an extra line space between scores.